### PR TITLE
MongoDB Authentication and Lazy Initialization

### DIFF
--- a/web/dbpatterns/documents/__init__.py
+++ b/web/dbpatterns/documents/__init__.py
@@ -11,12 +11,14 @@ def get_connection():
             host=getattr(settings, 'MONGODB_HOST', None),
             port=getattr(settings, 'MONGODB_PORT', None)
         )
-        db = _connection[settings.MONGODB_DATABASE]
         username = getattr(settings, 'MONGODB_USERNAME', None)
         password = getattr(settings, 'MONGODB_PASSWORD', None)
+        db = _connection[settings.MONGODB_DATABASE]
         if username and password:
             db.authenticate(username, password)
-    return db
+        return db
+    return _connection[settings.MONGODB_DATABASE]
+
 connection = SimpleLazyObject(get_connection)
 
 


### PR DESCRIPTION
If authentication credentials are provided, we are trying to authenticate before getting the reference of the db connection.

The following credentials should be put into the settings file. They are not mandatory.

**MONGODB_USERNAME**: "ozgur"
**MONGODB_PASSWORD**: "dummy"

Besides, I also wrapped the mongodb connection with a lazy object in order to defer its initialization until actually needed. 
